### PR TITLE
build: prevent mounting node_modules volume

### DIFF
--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -34,6 +34,7 @@ services:
       retries: 5
     volumes:
       - ../frontend:/app
+      - /app/node_modules
     ports:
       - "3000:3000"
 


### PR DESCRIPTION
Not to have to exec `npm install` when running the app for the first time.

Related to #8 