### PR TITLE
fix(auth): refresh access token during navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,6 @@ import MainContextProvider from "./contexts/mainContext";
 import ProjectSheet from "./pages/projectSheet";
 import DeploymentSheet from "./pages/deploymentSheet";
 import DeviceMenuPage from "./pages/deviceMenu";
-import DeviceSheet from "./components/deviceSheet/deviceSheetMain";
 import DeviceSheetPage from "./pages/deviceSheet";
 import { theme } from "./theme";
 import { LinearProgress, ThemeProvider } from "@mui/material";
@@ -18,9 +17,9 @@ import SiteMenuPage from "./pages/siteMenu";
 import SiteSheetPage from "./pages/siteSheet";
 import SnackContextProvider from "./contexts/snackContext";
 import { AuthContext } from "./contexts/AuthContextProvider";
-import { useContext } from "react";
+import { useContext} from "react";
 import FilesContextProvider from "./contexts/filesContext";
-;
+import RouteWrapper from "./components/RouteWrapper";
 
 // Env var processed by nginx
 OpenAPI.BASE = window._env_.REACT_APP_API_PATH || "/api/v1";
@@ -39,43 +38,103 @@ function App() {
               <I18nextProvider i18n={i18n}>
                 <BrowserRouter>
                   <Routes>
-                    <Route path="/" element={<Main />}></Route>
-                    {/* <Route path="/project/:projectId" element={<Project />}></Route> */}
+                    <Route
+                      path="/"
+                      element={
+                        <RouteWrapper>
+                          <Main />
+                        </RouteWrapper>
+                      }
+                    />
+                    {/* <Route path="/project/:projectId" element={<Project />} /> */}
                     <Route
                       path="/project/:projectId"
-                      element={<ProjectSheet />}
-                    ></Route>
-                    <Route path="/sites/" element={<SiteMenuPage />}></Route>
-                    <Route path="/devices/" element={<DeviceMenuPage />}></Route>
+                      element={
+                        <RouteWrapper>
+                          <ProjectSheet />
+                        </RouteWrapper>
+                      }
+                    />
+                    <Route
+                      path="/sites/"
+                      element={
+                        <RouteWrapper>
+                          <SiteMenuPage />
+                        </RouteWrapper>
+                      }
+                    />
+                    <Route
+                      path="/devices/"
+                      element={
+                        <RouteWrapper>
+                          <DeviceMenuPage />
+                        </RouteWrapper>
+                      }
+                    />
                     <Route
                       path="/devices/:deviceId"
-                      element={<DeviceSheetPage />}
-                    ></Route>
+                      element={
+                        <RouteWrapper>
+                          <DeviceSheetPage />
+                        </RouteWrapper>
+                      }
+                    />
                     <Route
                       path="/sites/:siteId"
-                      element={<SiteSheetPage />}
-                    ></Route>
+                      element={
+                        <RouteWrapper>
+                          <SiteSheetPage />
+                        </RouteWrapper>
+                      }
+                    />
                     <Route
                       path="deployment/:deploymentId"
-                      element={<Deployment />}
-                    ></Route>
+                      element={
+                        <RouteWrapper>
+                          <Deployment />
+                        </RouteWrapper>
+                      }
+                    />
                     <Route
                       path="/project/:projectId/deployment/:deploymentId/details"
-                      element={<DeploymentSheet number={0} />}
-                    ></Route>
+                      element={
+                        <RouteWrapper>
+                          <DeploymentSheet number={0} />
+                        </RouteWrapper>
+                      }
+                    />
                     <Route
                       path="/project/:projectId/deployment/:deploymentId/medias"
-                      element={<DeploymentSheet number={1} />}
-                    ></Route>
+                      element={
+                        <RouteWrapper>
+                          <DeploymentSheet number={1} />
+                        </RouteWrapper>
+                      }
+                    />
                     <Route
                       path="/project/:projectId/deployment/:deploymentId/medias/:imageId"
-                      element={<Annotation />}
-                    ></Route>
+                      element={
+                        <RouteWrapper>
+                          <Annotation />
+                        </RouteWrapper>
+                      }
+                    />
                     <Route
                       path="/project/:projectId/deployment/:deploymentId/details/:imageId"
-                      element={<Annotation />}
-                    ></Route>
-                    <Route path="*" element={<Main />}></Route>
+                      element={
+                        <RouteWrapper>
+                          <Annotation />
+                        </RouteWrapper>
+                      }
+                    />
+                    <Route
+                      path="*"
+                      element={
+                        <RouteWrapper>
+                          <Main />
+                        </RouteWrapper>
+                      }
+                    />
                   </Routes>
                 </BrowserRouter>
               </I18nextProvider>

--- a/frontend/src/components/RouteWrapper.tsx
+++ b/frontend/src/components/RouteWrapper.tsx
@@ -1,4 +1,3 @@
-
 import { useRefreshToken } from "../hooks/useRefreshToken";
 
 /**

--- a/frontend/src/components/RouteWrapper.tsx
+++ b/frontend/src/components/RouteWrapper.tsx
@@ -1,0 +1,17 @@
+
+import { useRefreshToken } from "../hooks/useRefreshToken";
+
+/**
+ * A wrapper around the element rendered by the React Router <Route> component.
+ *
+ * Useful to trigger code when the route changes.
+ */
+const RouteWrapper = ({children}: {children: React.ReactNode}) => {
+  useRefreshToken();
+
+  return (
+    <>{children}</>
+  );
+}
+
+export default RouteWrapper;

--- a/frontend/src/hooks/useRefreshToken.ts
+++ b/frontend/src/hooks/useRefreshToken.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect, useContext } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import { OpenAPI } from '../client';
+import { AuthContext } from '../contexts/AuthContextProvider';
+import keycloak from '../keycloak';;
+
+
+const TOKEN_MIN_VALIDITY = 120;
+
+
+export const useRefreshToken = () => {
+  const [pending, setPending] = useState(true);
+  const location = useLocation();
+  const { logout } = useContext(AuthContext);
+
+  const onTokenRefresh = (token: string | undefined) => {
+    if (token) {
+      OpenAPI.TOKEN = token;
+    }
+  }
+
+  useEffect(() => {
+    const refreshToken = async () => {
+      try {
+        const refreshed = await keycloak.updateToken(TOKEN_MIN_VALIDITY);
+        if (refreshed) {
+          onTokenRefresh(keycloak.token);
+        }
+        setPending(false);
+      } catch (error) {
+        logout();
+      }
+    }
+
+    refreshToken();
+  }, [location]);
+
+  return { pending };
+};


### PR DESCRIPTION
### Description

This branch is a first step to fix the access token refresh, currently not performed automatically by the front end. The proposed strategy is the following:
- step 1, refresh the access token, if needed, when a new page is loaded
- step 2, refresh the access token, if needed, before all HTTP POST requests
- step 3, discover limitations, and fix them :)

This branch implements the step 1.

### Changes

The access token expiration date is now automatically checked during the user navigation, thanks to a new hook `useRefreshToken`. If both the access token and refresh token are expired, the Keycloak logout is triggered.

This will ensure that all HTTP GET requests performed during a page load are made with a valid access token.

### Limitations

Note that `useRefreshToken` performs an asynchronous request to refresh the access token. During this process it is possible that the displayed page starts to make HTTP requests with an expired access token. If such cases happen, we will be able to use the `pending` state returned by the hook `useRefreshToken` to delay the page rendering accordingly.

### Next steps

After this branch is merged, I'll implement the step 2.