### PR TITLE
fix: store sinp nomenclature files in github

### DIFF
--- a/nomenclapi/Dockerfile
+++ b/nomenclapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-buster
+FROM python:3.8-slim-bullseye
  
 ENV MODE development
  

--- a/nomenclapi/main.py
+++ b/nomenclapi/main.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI
 
 app = FastAPI()
 
-FILE_URL = "https://inpn.mnhn.fr/docs-web/docs/download/421876"
+FILE_URL = "https://github.com/naturalsolutions/ecoSecrets/raw/refs/heads/dev/nomenclapi/nomenclatures_SINP_mai2023.zip"
 FILENAMES = {
     "sex": "sexeValue_100523.xlsx",
     "life_stage": "stadeBiologiqueValue_100523.xlsx",


### PR DESCRIPTION
- inpn.mnhn server is unvalaible => store sinp nomenclature in nomenclapi folder on github
- replace deprecate python image