### PR TITLE
fix: add frontend media pagination

### DIFF
--- a/api/src/routers/files.py
+++ b/api/src/routers/files.py
@@ -48,7 +48,8 @@ def update_annotations(file_id: uuid_pkg.UUID, data: UpdateFile, db: Session = D
 
 @router.get("/filters/{deployment_id}")
 def get_files_with_filters(
-    deployment_id: int, filters_params: FilterParams = Depends(),
+    deployment_id: int,
+    filters_params: FilterParams = Depends(),
     db: Session = Depends(get_db),
     skip: int = Query(0, ge=0),
     limit: int = Query(100, le=100),

--- a/api/src/routers/files.py
+++ b/api/src/routers/files.py
@@ -46,12 +46,15 @@ def update_annotations(file_id: uuid_pkg.UUID, data: UpdateFile, db: Session = D
     return files.update_annotations(db, file_id=file_id, data=data)
 
 
-@router.get("/filters/{deployment_id}", response_model=List[ReadFiles])
+@router.get("/filters/{deployment_id}")
 def get_files_with_filters(
-    deployment_id: int, filters_params: FilterParams = Depends(), db: Session = Depends(get_db)
+    deployment_id: int, filters_params: FilterParams = Depends(),
+    db: Session = Depends(get_db),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(100, le=100),
 ):
     return files.get_deployment_files_with_filters(
-        db=db, deployment_id=deployment_id, filters_params=filters_params
+        db=db, deployment_id=deployment_id, filters_params=filters_params, skip=skip, limit=limit
     )
 
 

--- a/api/src/services/files.py
+++ b/api/src/services/files.py
@@ -50,7 +50,7 @@ def get_deployment_files_with_filters(
         query = query.filter(Files.date >= start_date)
     elif end_date:
         query = query.filter(Files.date <= end_date)
-    
+
     total_items = query.count()
 
     query = query.order_by(Files.name).offset(skip).limit(limit)
@@ -66,7 +66,7 @@ def get_deployment_files_with_filters(
         "data": res,
         "total_items": total_items,
         "current_page": (skip // limit) + 1,
-        "total_pages": (total_items + limit - 1) // limit
+        "total_pages": (total_items + limit - 1) // limit,
     }
 
 

--- a/api/src/services/files.py
+++ b/api/src/services/files.py
@@ -50,6 +50,8 @@ def get_deployment_files_with_filters(
         query = query.filter(Files.date >= start_date)
     elif end_date:
         query = query.filter(Files.date <= end_date)
+    
+    total_items = query.count()
 
     query = query.order_by(Files.name).offset(skip).limit(limit)
 
@@ -60,7 +62,12 @@ def get_deployment_files_with_filters(
         url = s3.get_url(f"{f.hash}.{f.extension}")
         new_f["url"] = url
         res.append(new_f)
-    return res
+    return {
+        "data": res,
+        "total_items": total_items,
+        "current_page": (skip // limit) + 1,
+        "total_pages": (total_items + limit - 1) // limit
+    }
 
 
 def get_deployment_files(db: Session, id: int, skip: int = 0, limit: int = 10000):

--- a/frontend/src/client/services/FilesService.ts
+++ b/frontend/src/client/services/FilesService.ts
@@ -62,6 +62,8 @@ export class FilesService {
     /**
      * Get Files With Filters
      * @param deploymentId
+     * @param skip
+     * @param limit
      * @param species
      * @param family
      * @param genus
@@ -74,6 +76,8 @@ export class FilesService {
      */
     public static getFilesWithFiltersFilesFiltersDeploymentIdGet(
         deploymentId: number,
+        skip?: number,
+        limit: number = 100,
         species?: string,
         family?: string,
         genus?: string,
@@ -89,6 +93,8 @@ export class FilesService {
                 'deployment_id': deploymentId,
             },
             query: {
+                'skip': skip,
+                'limit': limit,
                 'species': species,
                 'family': family,
                 'genus': genus,

--- a/frontend/src/components/annotation/AnnotationGroupModale.tsx
+++ b/frontend/src/components/annotation/AnnotationGroupModale.tsx
@@ -14,7 +14,7 @@ const AnnotationGroupModale = () => {
 
     const { currentDeployment } = useMainContext();
 
-    const { updateListFile, currentImage } = useFilesContext();
+    const { updateListFile, currentImage, paginationFiles,imagePerPage } = useFilesContext();
 
     const { openAnnotationGroupModale, setOpenAnnotationGroupModale, observations, idGroup, selectedGroupedObservation, unselectedGroupedObservation, setSelectedGroupedObservation, setUnselectedGroupedObservation, modifiedObservationGroup,setModifiedObservationGroup, next } = useAnnotationContext();
 
@@ -60,7 +60,7 @@ const AnnotationGroupModale = () => {
               deployment_id: currentDeployment
             })
             .then(res => {
-                updateListFile();
+                updateListFile((paginationFiles.currentPage -1) *imagePerPage);
                 next();
             })
             .catch((err) => {

--- a/frontend/src/components/annotation/AnnotationImageNavigation.tsx
+++ b/frontend/src/components/annotation/AnnotationImageNavigation.tsx
@@ -9,7 +9,7 @@ import FastRewindIcon from '@mui/icons-material/FastRewind';
 
 const AnnotationImageNavigation = () => {
 
-    const { files, currentImage } = useFilesContext();
+    const { files, currentImage, paginationFiles, imagePerPage } = useFilesContext();
     const { previous, lastOrFirstImage, next } = useAnnotationContext();
 
     const imageIndex = () => {
@@ -38,7 +38,7 @@ const AnnotationImageNavigation = () => {
                         variant="h6" 
                         style={{ backgroundColor: "#f5f5f5" }}
                     >
-                        { imageIndex() + " | " + files.length }
+                        { imageIndex()+ (paginationFiles.currentPage -1 )*imagePerPage + " | " + paginationFiles.totalFiles }
                     </Typography>
                 </IconButton>
 

--- a/frontend/src/components/annotation/ButtonDeleteMedia.tsx
+++ b/frontend/src/components/annotation/ButtonDeleteMedia.tsx
@@ -16,13 +16,13 @@ const ButtonDeleteMedia = () => {
     const { t } = useTranslation();
 
     const { next } = useAnnotationContext();
-    const { currentImage, updateListFile } = useFilesContext();
+    const { currentImage, updateListFile, paginationFiles,imagePerPage } = useFilesContext();
 
     const [open, setOpen] = useState(false);
 
     const save = () => {
       FilesService.deleteFileFilesDeleteFileIdDelete(currentImage).then((res) => {
-        updateListFile();
+        updateListFile((paginationFiles.currentPage -1) *imagePerPage);
         setOpen(false);
         next();
       }).catch((err) => console.error("Erreur:", err));

--- a/frontend/src/components/annotation/MetadataDateTimeInput.tsx
+++ b/frontend/src/components/annotation/MetadataDateTimeInput.tsx
@@ -20,7 +20,7 @@ interface MetadataDateTimeInputProps {
 const MetadataDateTimeInput: FC<MetadataDateTimeInputProps> = (props) => {
   const { t } = useTranslation();
   const { currentDeployment } = useMainContext();
-  const { currentImage, files, updateListFile } = useFilesContext();
+  const { currentImage, files, updateListFile, paginationFiles, imagePerPage } = useFilesContext();
   const [date, setDate] = useState<Date | null>(props.date);
   const [toSave, setToSave] = useState<boolean>(false);
 
@@ -44,7 +44,7 @@ const MetadataDateTimeInput: FC<MetadataDateTimeInputProps> = (props) => {
     })
       .then((res) => {
         setToSave(false);
-        updateListFile();
+        updateListFile((paginationFiles.currentPage -1) *imagePerPage);
       })
       .catch((err) => {
         console.log("Error during metadata saving.");

--- a/frontend/src/components/deployments/mediaGallery.tsx
+++ b/frontend/src/components/deployments/mediaGallery.tsx
@@ -1,13 +1,23 @@
 import Masonry from "@mui/lab/Masonry";
-import { Box, capitalize, Typography } from "@mui/material";
+import { Box, capitalize, Pagination, Typography } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import GalleryItem from "./GalleryItem";
 import MediaFilters from "./Filters";
 import { useFilesContext } from "../../contexts/filesContext";
+import { useEffect, useState } from "react";
 
 export default function MediaGallery() {
-  const { files } = useFilesContext();
+  const { files, paginationFiles, updateListFile } = useFilesContext();
+  const [page, setPage] = useState(1);
   const { t } = useTranslation();
+
+  const handleChangePage = (event, newPage) => {
+    setPage(newPage);
+  };
+
+  useEffect(() => {
+    updateListFile((page - 1) * 24, 24);
+  }, [page]);
 
   return (
     <Box
@@ -30,6 +40,13 @@ export default function MediaGallery() {
           <p>{capitalize(t("main.no_data"))}</p>
         )}
       </Masonry>
+      <Pagination
+        count={paginationFiles?.totalPages}
+        page={page}
+        onChange={handleChangePage}
+        color="primary"
+        style={{ marginTop: "20px", display: "flex", justifyContent: "center" }}
+      />
     </Box>
   );
 }

--- a/frontend/src/contexts/annotationContext.tsx
+++ b/frontend/src/contexts/annotationContext.tsx
@@ -17,7 +17,7 @@ export function AnnotationContextProvider({ children }) {
 
     const { projects, currentDeployment, setCurrentDeployment, setCurrentProject } = 
     useMainContext();
-    const { image, updateListFile, currentImage, setCurrentImage, files } =
+    const { image, updateListFile, currentImage, setCurrentImage, files, paginationFiles, imagePerPage } =
     useFilesContext();
     const [observations, setObservations] = useState<Annotation[]>([]);
     const [metadata, setMetadata] = useState<MetadataData>();
@@ -52,37 +52,78 @@ export function AnnotationContextProvider({ children }) {
         window.history.pushState({}, "", url);
     };
 
-    const previous = () => {
-        files.forEach((f, i) => {
-            if (f.id === currentImage) {
-                let ind = i === 0 ? (i = files.length) : i;
-                setCurrentImage(files[ind - 1].id);
-
-                updateUrl(files[ind - 1].id);
+    const previous = async () => {
+        const index = files.findIndex(f => f.id === currentImage);
+        if (index === -1) return;
+        if (index === 0) {
+            if (paginationFiles.currentPage > 1) {
+                await updateListFile(
+                    (paginationFiles.currentPage - 2) * imagePerPage,
+                    { idx: imagePerPage-1, projectId:params.projectId, deploymentId: params.deploymentId }
+                );
+    
+                setIsMinimalObservation(true);
+                return;
             }
-        });
-        setIsMinimalObservation(true);
-    };
-
-    const next = () => {
-        files.forEach((f, i) => {
-            if (f.id === currentImage) {
-                let ind = i === files.length - 1 ? -1 : i;
-                setCurrentImage(files[ind + 1].id);
-                updateUrl(files[ind + 1].id);
-            }
-        });
-        setIsMinimalObservation(true);
-    };
-
-    const lastOrFirstImage = (indice) => {
-        if (indice === 'first') {
-            setCurrentImage(files[0].id);
-            updateUrl(files[0].id);
+            setIsMinimalObservation(true);
+            return;
         }
-        if (indice === 'last') {
-            setCurrentImage(files[files.length - 1].id);
-            updateUrl(files[files.length - 1].id);
+        const prevImage = files[index - 1];
+        setCurrentImage(prevImage.id);
+        updateUrl(prevImage.id);
+        setIsMinimalObservation(true);
+    };
+    
+
+    const next = async () => {
+        const index = files.findIndex(f => f.id === currentImage);
+        if (index === -1) return;
+        if (index === files.length - 1) {
+            if (paginationFiles.currentPage < paginationFiles.totalPages) {
+                await updateListFile(
+                    (paginationFiles.currentPage +1 -1) *imagePerPage,
+                    { idx: 0, projectId:params.projectId, deploymentId: params.deploymentId }
+                );
+                setIsMinimalObservation(true);
+                return;
+            }
+            setIsMinimalObservation(true);
+            return;
+        }
+        const nextImage = files[index + 1];
+        setCurrentImage(nextImage.id);
+        updateUrl(nextImage.id);
+    
+        setIsMinimalObservation(true);
+    };
+    
+
+    const lastOrFirstImage = async (position: 'first' | 'last') => {
+        if (files.length === 0) return;
+        if (position === 'first') {
+            if (paginationFiles.currentPage > 1 || files[0].id !== currentImage) {
+                await updateListFile(
+                    0,
+                    { idx: 0, projectId:params.projectId, deploymentId: params.deploymentId}
+                );
+            } else {
+                setCurrentImage(files[0].id);
+                updateUrl(files[0].id);
+            }
+            setIsMinimalObservation(true);
+            return;
+        }
+    
+        if (position === 'last') {
+            if (paginationFiles.currentPage < paginationFiles.totalPages || files[files.length - 1].id !== currentImage) {
+                const lastPageSkip = (paginationFiles.totalPages - 1) * imagePerPage;
+                await updateListFile(lastPageSkip, { idx: imagePerPage-1, projectId:params.projectId, deploymentId: params.deploymentId });
+            } else {
+                setCurrentImage(files[files.length - 1].id);
+                updateUrl(files[files.length - 1].id);
+            }
+            setIsMinimalObservation(true);
+            return;
         }
     };
 
@@ -95,7 +136,7 @@ export function AnnotationContextProvider({ children }) {
                 FilesService
                 .updateAnnotationsFilesAnnotationFileIdPatch(currentImage, { annotations: { annotations:  observations, id_group: idGroup }, deployment_id: currentDeployment} )
                 .then(res => {
-                    updateListFile();
+                    updateListFile((paginationFiles.currentPage -1) *imagePerPage); 
                     next();
                 })
                 .catch((err) => {
@@ -117,7 +158,7 @@ export function AnnotationContextProvider({ children }) {
                     FilesService
                     .updateAnnotationsFilesAnnotationFileIdPatch(item.id, { annotations: { annotations:  observations, id_group: idGroup }, deployment_id: currentDeployment} )
                     .then(res => {
-                        updateListFile();
+                        updateListFile((paginationFiles.currentPage -1) *imagePerPage);
                     })
                     .catch((err) => {
                         console.log("Error during annotation saving.");

--- a/frontend/src/contexts/filesContext.tsx
+++ b/frontend/src/contexts/filesContext.tsx
@@ -11,6 +11,13 @@ interface Filters {
   start_date: Date | null;
   end_date: Date | null;
 }
+
+interface Pagination {
+  totalFiles: number;
+  currentPage: number;
+  totalPages: number;
+}
+
 export interface FilesContextProps {
   name?: string;
   children?: any;
@@ -21,6 +28,7 @@ export const useFilesContext = () => useContext(FilesContext);
 
 const FilesContextProvider: FC<FilesContextProps> = ({ children }) => {
   const { currentDeployment, updateDeploymentData } = useMainContext();
+  const [paginationFiles, setPaginationFiles] = useState<Pagination>();
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
   const [files, setFiles] = useState<any[]>([]);
   const [currentImage, setCurrentImage] = useState<string | null>(null);
@@ -38,11 +46,13 @@ const FilesContextProvider: FC<FilesContextProps> = ({ children }) => {
     return files.find((f) => f.id === currentImage);
   };
 
-  const updateListFile = () => {
+  const updateListFile = (skip = 0, limit = 100) => {
     setIsLoaded(false);
     currentDeployment &&
       FilesService.getFilesWithFiltersFilesFiltersDeploymentIdGet(
         currentDeployment,
+        skip,
+        limit,
         filters?.species,
         filters?.family,
         filters?.genus,
@@ -52,8 +62,12 @@ const FilesContextProvider: FC<FilesContextProps> = ({ children }) => {
         filters?.end_date?.toISOString().slice(0, -1)
       )
         .then((files) => {
-          setFiles(files);
-          setIsLoaded(true);
+          setFiles(files["data"]);
+          setPaginationFiles({
+            currentPage: files["current_page"],
+            totalFiles: files["total_items"],
+            totalPages: files["total_pages"],
+          });
         })
         .catch((err) => {
           console.log(err);
@@ -78,6 +92,8 @@ const FilesContextProvider: FC<FilesContextProps> = ({ children }) => {
         setCurrentImage,
         image,
         isLoaded,
+        paginationFiles,
+        setPaginationFiles,
       }}
     >
       {children}

--- a/frontend/src/contexts/filesContext.tsx
+++ b/frontend/src/contexts/filesContext.tsx
@@ -31,6 +31,7 @@ const FilesContextProvider: FC<FilesContextProps> = ({ children }) => {
   const [paginationFiles, setPaginationFiles] = useState<Pagination>();
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
   const [files, setFiles] = useState<any[]>([]);
+  const imagePerPage = 24;
   const [currentImage, setCurrentImage] = useState<string | null>(null);
   const [filters, setFilters] = useState<Filters>({
     species: "",
@@ -46,33 +47,57 @@ const FilesContextProvider: FC<FilesContextProps> = ({ children }) => {
     return files.find((f) => f.id === currentImage);
   };
 
-  const updateListFile = (skip = 0, limit = 100) => {
-    setIsLoaded(false);
-    currentDeployment &&
-      FilesService.getFilesWithFiltersFilesFiltersDeploymentIdGet(
-        currentDeployment,
-        skip,
-        limit,
-        filters?.species,
-        filters?.family,
-        filters?.genus,
-        filters?.classe,
-        filters?.order,
-        filters?.start_date?.toISOString().slice(0, -1),
-        filters?.end_date?.toISOString().slice(0, -1)
-      )
-        .then((files) => {
-          setFiles(files["data"]);
-          setPaginationFiles({
-            currentPage: files["current_page"],
-            totalFiles: files["total_items"],
-            totalPages: files["total_pages"],
-          });
-        })
-        .catch((err) => {
-          console.log(err);
-        });
+  const updateUrl = (projectId, deploymentId, id) => {
+    const url = new URL(window.location.toString());
+    url.pathname = `/project/${Number(projectId)}/deployment/${Number(
+      deploymentId
+    )}/medias/${id}`;
+    window.history.pushState({}, "", url);
   };
+
+
+  const updateListFile = (
+    skip: number = 0,
+    options: { idx?: number, projectId?: any, deploymentId?: any} = {}
+  ): Promise<void> => {
+    
+    const { idx, projectId, deploymentId } = options;
+    setIsLoaded(false);
+
+    if (!currentDeployment) return Promise.resolve();
+
+    return FilesService.getFilesWithFiltersFilesFiltersDeploymentIdGet(
+      currentDeployment,
+      skip,
+      imagePerPage,
+      filters?.species,
+      filters?.family,
+      filters?.genus,
+      filters?.classe,
+      filters?.order,
+      filters?.start_date?.toISOString().slice(0, -1),
+      filters?.end_date?.toISOString().slice(0, -1)
+    )
+      .then((files) => {
+        setIsLoaded(true);
+        setFiles(files.data);
+        setPaginationFiles({
+          currentPage: files.current_page,
+          totalFiles: files.total_items,
+          totalPages: files.total_pages,
+        });
+        if (idx !== undefined) {
+          const minIdx = Math.min(idx, files["data"].length - 1);
+          const currentImageId = files["data"][minIdx].id;
+          setCurrentImage(currentImageId);
+          updateUrl(projectId ,deploymentId, currentImageId);
+        }
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  };
+
 
   useEffect(() => {
     (async () => {
@@ -94,6 +119,7 @@ const FilesContextProvider: FC<FilesContextProps> = ({ children }) => {
         isLoaded,
         paginationFiles,
         setPaginationFiles,
+        imagePerPage
       }}
     >
       {children}


### PR DESCRIPTION
Côté API la route de récupération des médias est paginé mais il n'est pas possible pour l'utilisateur dans l'interface de changer de page :

- Ajout pagination des médias sur la page de galerie

<img width="1752" height="903" alt="image" src="https://github.com/user-attachments/assets/18359525-1bf1-4314-bf47-b896abca83f4" />

- Pagination sur la page d'annotation :
<img width="1845" height="828" alt="image" src="https://github.com/user-attachments/assets/65f3bfea-cdb4-4890-8532-6bb4d90edac9" />
